### PR TITLE
SLING-9825 SLING-9826 remove the duplicate components in the Jcr/Oak config

### DIFF
--- a/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java
+++ b/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java
@@ -30,6 +30,7 @@ import javax.jcr.Repository;
 
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.JackrabbitRepository;
+import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.Oak;
 import org.apache.jackrabbit.oak.jcr.Jcr;
 import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
@@ -38,6 +39,7 @@ import org.apache.jackrabbit.oak.plugins.index.WhiteboardIndexEditorProvider;
 import org.apache.jackrabbit.oak.plugins.index.aggregate.SimpleNodeAggregator;
 import org.apache.jackrabbit.oak.plugins.index.lucene.util.LuceneIndexHelper;
 import org.apache.jackrabbit.oak.plugins.observation.CommitRateLimiter;
+import org.apache.jackrabbit.oak.plugins.version.VersionHook;
 import org.apache.jackrabbit.oak.spi.commit.WhiteboardEditorProvider;
 import org.apache.jackrabbit.oak.spi.lifecycle.RepositoryInitializer;
 import org.apache.jackrabbit.oak.spi.query.QueryIndex.NodeAggregator;
@@ -125,9 +127,11 @@ public class OakSlingRepositoryManager extends AbstractSlingRepositoryManager {
         final Oak oak = new Oak(nodeStore)
             .withAsyncIndexing("async", 5);
 
-        final Jcr jcr = new Jcr(oak)
+        final Jcr jcr = new Jcr(oak, false)
+            .with(new InitialContent())
             .with(new ExtraSlingContent())
             .with(JcrConflictHandler.createJcrConflictHandler())
+            .with(new VersionHook())
             .with(whiteboard)
             .with(securityProvider)
             .with(editorProvider)

--- a/src/test/java/org/apache/sling/jcr/oak/server/it/Sling9826IT.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/it/Sling9826IT.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.oak.server.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.InvalidQueryException;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.commons.JcrUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+
+@RunWith(PaxExam.class)
+public class Sling9826IT extends OakServerTestSupport {
+	private Session adminSession = null;
+	private String testFolderPath;
+	private String temp1Path;
+	private String temp2Path;
+	
+	@Before
+	public void setup() throws RepositoryException {
+        adminSession = (JackrabbitSession)slingRepository.loginAdministrative(null);
+        
+        Node testFolder = JcrUtils.getOrCreateByPath("/content/sling9826", true, "sling:Folder", "sling:Folder", adminSession, false);
+        testFolderPath = testFolder.getPath();
+        Node temp1Node = JcrUtils.getOrCreateByPath(testFolder, "temp1", true, "sling:Folder", "sling:Folder", false);
+        temp1Path = temp1Node.getPath();
+        Node temp2Node = JcrUtils.getOrCreateByPath(testFolder, "temp2", true, "sling:Folder", "sling:Folder", false);
+        temp2Path = temp2Node.getPath();
+		if (adminSession.hasPendingChanges()) {
+			adminSession.save();
+		}
+	}
+	
+	@After
+	public void teardown() throws RepositoryException {
+		if (adminSession != null) {
+			adminSession.refresh(false);
+
+			if (testFolderPath != null && adminSession.itemExists(testFolderPath)) {
+				adminSession.getItem(testFolderPath).remove();
+			}
+			
+			if (adminSession.hasPendingChanges()) {
+				adminSession.save();
+			}
+			
+			adminSession.logout();
+		}
+		adminSession = null;
+		temp1Path = null;
+		temp2Path = null;
+		testFolderPath = null;
+	}
+	
+	/**
+	 * SLING-9826 - test that jcr:uuid index is updated on move
+	 */
+    @Test
+    public void checkUuidIndexUpdatedOnMove() throws Exception {
+		// create the node to move
+    	Node parent = adminSession.getNode(temp1Path);
+	    String childName = "child" + System.currentTimeMillis();
+	    Node child = parent.addNode(childName, "sling:Folder");
+	    child.addMixin("mix:referenceable");
+	    adminSession.save();
+	    
+	    // verify the id and lookup by id and query works 
+	    String id = child.getIdentifier();
+	    assertNotNull(adminSession.getNodeByIdentifier(id));
+	    verifyLookupByIdentifier(id);
+
+	    // move it
+	    adminSession.move(child.getPath(), temp2Path + childName);
+	    adminSession.save();
+	    
+	    // verify the id and lookup by id and query works 
+	    verifyLookupByIdentifier(id);
+    }
+
+	protected void verifyLookupByIdentifier(String id)
+			throws ItemNotFoundException, RepositoryException, InvalidQueryException {
+		// verify lookup by id
+	    Node nodeByIdentifier = adminSession.getNodeByIdentifier(id);
+	    assertNotNull(nodeByIdentifier);
+	    assertEquals(id, nodeByIdentifier.getIdentifier());
+
+	    // verify lookup by query
+	    Query query = adminSession.getWorkspace().getQueryManager().createQuery(String.format("SELECT * FROM [nt:base] WHERE [jcr:uuid] = '%s'", id), Query.JCR_SQL2);
+	    QueryResult execute = query.execute();
+	    NodeIterator nodes = execute.getNodes();
+	    assertTrue(nodes.hasNext());
+	    Node nextNode = nodes.nextNode();
+	    assertNotNull(nextNode);
+	    assertEquals(id, nextNode.getIdentifier());
+	}
+    
+}


### PR DESCRIPTION
In the 1.2.8 Oak/Jcr config the editorProvider, indexEditorProvider and queryIndexProvider config lists had some of the components twice, once coming from the OakDefaultComponents set and the same again via the Whiteboard*Provider components. 

This fix removes the duplicate components.

