### PR TITLE
SLING-12035 bump oak dependency for compatibility with version 1.56.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@
 This module is part of the [Apache Sling](https://sling.apache.org) project.
 
 This bundle provides a SlingRepository based on Apache Jackrabbit Oak.
+
+
+## Compatibility
+
+When paring the bundles in your installation, these are the version combinations that would be compatible:
+
+| Apache Sling JCR Oak Server | Apache Jackrabbit Oak |
+|---|---|
+| 1.3.0 | 1.8.9 to 1.54.0 |
+| 1.4.0 or later | 1.56.0 or later |

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -12,7 +12,8 @@ Provide-Capability:\
   osgi.service;objectClass:List<String>="java.util.concurrent.Executor,org.apache.sling.commons.threads.ThreadPool"
 
 -includeresource:\
-  @oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/lucene/util/LuceneIndexHelper.*
+  @oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/lucene/util/LuceneIndexHelper.*,\
+  @oak-search-*.jar!/org/apache/jackrabbit/oak/plugins/index/search/util/IndexHelper.*
 
 -removeheaders:\
   Include-Resource,\

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </parent>
 
   <artifactId>org.apache.sling.jcr.oak.server</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
 
   <name>Apache Sling JCR Oak Server</name>
   <description>This bundle provides a SlingRepository based on Apache Jackrabbit Oak.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <javadoc.excludePackageNames />
     <jackrabbit.version>2.16.3</jackrabbit.version>
-    <oak.version>1.8.9</oak.version>
+    <oak.version>1.56.0</oak.version>
     <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
     <project.build.outputTimestamp>2022-05-12T20:23:08Z</project.build.outputTimestamp>
   </properties>

--- a/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
@@ -150,6 +150,30 @@ public abstract class OakServerTestSupport extends TestSupport {
 
     @Configuration
     public Option[] configuration() {
+        // SLING-12035 - bump the oak artifacts to the 1.56.0 version
+        //   remove this block after the versionResolver has these versions or later
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-api", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-authorization-principalbased", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob-plugins", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-commons", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-core", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-core-spi", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-jackrabbit-api", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-jcr", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-lucene", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-query-spi", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-security-spi", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-segment-tar", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-composite", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-document", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-spi", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-shaded-guava", "1.56.0");
+        // SLING-12035 - bump the related artifacts to the compatible versions
+        //   remove this block after the versionResolver has these versions or later
+        versionResolver.setVersion("commons-codec", "commons-codec", "1.16.0");
+        versionResolver.setVersion("commons-io", "commons-io", "2.13.0");
+
         return new Option[]{
             baseConfiguration(),
             quickstart(),
@@ -189,6 +213,10 @@ public abstract class OakServerTestSupport extends TestSupport {
                     "org.apache.sling.resourceresolver"
                 })
                 .asOption()
+        ).add(
+            // SLING-12035 - add extra bundle for the shaded version of guava used by the latest oak releases
+            //   remove this block after the SlingOptions#jackrabbitOak includes this artifact
+            mavenBundle().groupId("org.apache.jackrabbit").artifactId("oak-shaded-guava").version(versionResolver)
         );
     }
 


### PR DESCRIPTION
In order for sling to work with the latest release of oak, the oak dependencies must be bumped to 1.56.0 or later.

The oak 1.56.0 release completed the removal of the dependency on the old guava library which required a bump of the major version of some exported packages whose public api has changed.  The imports of those changed packages must be bumped to the new major version number in order for the bundles to resolve properly in the runtime.