### PR TITLE
SLING-12313 bump oak.version to 1.62.0 for compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <javadoc.excludePackageNames />
     <jackrabbit.version>2.16.3</jackrabbit.version>
-    <oak.version>1.62.0</oak.version>
+    <oak.version>1.70.0</oak.version>
     <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
     <project.build.outputTimestamp>2023-10-09T22:21:44Z</project.build.outputTimestamp>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <javadoc.excludePackageNames />
     <jackrabbit.version>2.16.3</jackrabbit.version>
-    <oak.version>1.56.0</oak.version>
+    <oak.version>1.62.0</oak.version>
     <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
     <project.build.outputTimestamp>2023-10-09T22:21:44Z</project.build.outputTimestamp>
   </properties>
@@ -65,6 +65,7 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <systemPropertyVariables>
+            <oak.version>${oak.version}</oak.version>
             <bundle.filename>${basedir}/target/${project.build.finalName}.jar</bundle.filename>
           </systemPropertyVariables>
         </configuration>

--- a/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
@@ -150,29 +150,30 @@ public abstract class OakServerTestSupport extends TestSupport {
 
     @Configuration
     public Option[] configuration() {
-        // SLING-12035 - bump the oak artifacts to the 1.56.0 version
+        String oakVersion = System.getProperty("oak.version", "1.62.0");
+        // SLING-12035 - bump the oak artifacts to the 1.62.0 version
         //   remove this block after the versionResolver has these versions or later
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-api", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-authorization-principalbased", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob-plugins", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-commons", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-core", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-core-spi", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-jackrabbit-api", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-jcr", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-lucene", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-query-spi", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-security-spi", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-segment-tar", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-composite", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-document", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-spi", "1.56.0");
-        versionResolver.setVersion("org.apache.jackrabbit", "oak-shaded-guava", "1.56.0");
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-api", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-authorization-principalbased", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-blob-plugins", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-commons", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-core", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-core-spi", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-jackrabbit-api", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-jcr", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-lucene", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-query-spi", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-security-spi", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-segment-tar", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-composite", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-document", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-store-spi", oakVersion);
+        versionResolver.setVersion("org.apache.jackrabbit", "oak-shaded-guava", oakVersion);
         // SLING-12035 - bump the related artifacts to the compatible versions
         //   remove this block after the versionResolver has these versions or later
         versionResolver.setVersion("commons-codec", "commons-codec", "1.16.0");
-        versionResolver.setVersion("commons-io", "commons-io", "2.13.0");
+        versionResolver.setVersion("commons-io", "commons-io", "2.15.0");
 
         return new Option[]{
             baseConfiguration(),

--- a/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
@@ -150,8 +150,7 @@ public abstract class OakServerTestSupport extends TestSupport {
 
     @Configuration
     public Option[] configuration() {
-        String oakVersion = System.getProperty("oak.version", "1.62.0");
-        // SLING-12035 - bump the oak artifacts to the 1.62.0 version
+        String oakVersion = System.getProperty("oak.version", "1.70.0");
         //   remove this block after the versionResolver has these versions or later
         versionResolver.setVersion("org.apache.jackrabbit", "oak-api", oakVersion);
         versionResolver.setVersion("org.apache.jackrabbit", "oak-authorization-principalbased", oakVersion);
@@ -172,8 +171,8 @@ public abstract class OakServerTestSupport extends TestSupport {
         versionResolver.setVersion("org.apache.jackrabbit", "oak-shaded-guava", oakVersion);
         // SLING-12035 - bump the related artifacts to the compatible versions
         //   remove this block after the versionResolver has these versions or later
-        versionResolver.setVersion("commons-codec", "commons-codec", "1.16.0");
-        versionResolver.setVersion("commons-io", "commons-io", "2.15.0");
+        versionResolver.setVersion("commons-codec", "commons-codec", "1.17.0");
+        versionResolver.setVersion("commons-io", "commons-io", "2.16.0");
 
         return new Option[]{
             baseConfiguration(),


### PR DESCRIPTION
Oak 1.62.0 has bumped the version of the shaded guava packages to a new major version (from 32 to 33) which results in a failure to resolve the o.a.sling.jcr.oak.server bundle with that version of the Oak bundles.

These errors are reported:
```org.osgi.framework.BundleException: Unable to resolve org.apache.sling.jcr.oak.server [144](R 144.0): missing requirement [org.apache.sling.jcr.oak.server [144](R 144.0)] osgi.wiring.package; (&(osgi.wiring.package=org.apache.jackrabbit.guava.common.base)(version>=32.1.0)(!(version>=33.0.0))) Unresolved requirements: [[org.apache.sling.jcr.oak.server [144](R 144.0)] osgi.wiring.package; (&(osgi.wiring.package=org.apache.jackrabbit.guava.common.base)(version>=32.1.0)(!(version>=33.0.0)))]```