### PR TITLE
SLING-12367 - Add MBeans registration

### DIFF
--- a/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java
+++ b/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java
@@ -130,7 +130,7 @@ public class OakSlingRepositoryManager extends AbstractSlingRepositoryManager {
     @Override
     protected Repository acquireRepository() {
         final BundleContext bundleContext = componentContext.getBundleContext();
-        final Whiteboard whiteboard = new OsgiWhiteboard(bundleContext);
+        final Whiteboard whiteboard = new WithMBeanRegistration(new OsgiWhiteboard(bundleContext));
         this.initializers = whiteboard.track(RepositoryInitializer.class);
         this.editorProvider.start(whiteboard);
         this.indexProvider.start(whiteboard);

--- a/src/main/java/org/apache/sling/jcr/oak/server/internal/WithMBeanRegistration.java
+++ b/src/main/java/org/apache/sling/jcr/oak/server/internal/WithMBeanRegistration.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.oak.server.internal;
+
+import org.apache.jackrabbit.oak.spi.whiteboard.Registration;
+import org.apache.jackrabbit.oak.spi.whiteboard.Tracker;
+import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.*;
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Wraps a {@link Whiteboard} and adds functionality for registering and unregistering MBeans.
+ */
+class WithMBeanRegistration implements Whiteboard {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WithMBeanRegistration.class);
+    private final Whiteboard wrappedWhiteboard;
+
+    private final Consumer<ObjectName> unregisterMBean = objectName -> {
+        try {
+            LOG.debug("Will attempt to unregister MBean: {}", objectName);
+            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            mBeanServer.unregisterMBean(objectName);
+            LOG.debug("MBean {} unregistered", objectName);
+        } catch (InstanceNotFoundException | MBeanRegistrationException exception) {
+            String errorMessage = String.format(
+                    "Failed to unregister MBean with with this ObjectName: [%s]", objectName
+            );
+            LOG.error(errorMessage, exception);
+        }
+    };
+
+    WithMBeanRegistration(Whiteboard wrappedWhiteboard) {
+        this.wrappedWhiteboard = wrappedWhiteboard;
+    }
+
+    @Override
+    public <T> Registration register(Class<T> type, T service, Map<?, ?> properties) {
+        Registration registration = wrappedWhiteboard.register(type, service, properties);
+        Optional<ObjectName> objectNameNullable = registerMBean(type, service, properties);
+        return () -> {
+            registration.unregister();
+            objectNameNullable.ifPresent(unregisterMBean);
+        };
+    }
+
+    @Override
+    public <T> Tracker<T> track(Class<T> type) {
+        return wrappedWhiteboard.track(type);
+    }
+
+    @Override
+    public <T> Tracker<T> track(Class<T> type, Map<String, String> filterProperties) {
+        return wrappedWhiteboard.track(type, filterProperties);
+    }
+
+    private Optional<ObjectName> extractObjectName(Map<?, ?> objectProperties) {
+        return Optional.ofNullable(objectProperties.get("jmx.objectname"))
+                       .flatMap(this::asObjectName);
+    }
+
+    private Optional<ObjectName> asObjectName(Object rawObjectName) {
+        if (rawObjectName instanceof ObjectName) {
+            return Optional.of((ObjectName) rawObjectName);
+        } else {
+            String objectAsString = String.valueOf(rawObjectName);
+            return asObjectName(objectAsString);
+        }
+    }
+
+    private Optional<ObjectName> asObjectName(String rawObjectName) {
+        try {
+            return Optional.of(new ObjectName(rawObjectName));
+        } catch (MalformedObjectNameException exception) {
+            String errorMessage = String.format("Failed to convert this object to ObjectName: %s", rawObjectName);
+            LOG.error(errorMessage, exception);
+            return Optional.empty();
+        }
+    }
+
+    private <T> void registerMBean(Class<T> expectedServiceType, T service, ObjectName objectName) {
+        LOG.trace("Will attempt to register MBean: {}", objectName);
+        try {
+            String expectedServiceTypeName = expectedServiceType.getName();
+            Class<?> actualServiceType = service.getClass();
+            String actualServiceTypeName = actualServiceType.getName();
+            String serviceMBeanName = actualServiceTypeName + "MBean";
+            boolean doesMatchMBeanExpectedType = expectedServiceTypeName.equals(serviceMBeanName);
+            boolean isMBeanInstance = service instanceof StandardMBean;
+            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            if (doesMatchMBeanExpectedType || isMBeanInstance) {
+                mBeanServer.registerMBean(service, objectName);
+            } else {
+                mBeanServer.registerMBean(new StandardMBean(service, expectedServiceType), objectName);
+            }
+            LOG.info("Registered MBean: {}", objectName);
+        } catch (InstanceAlreadyExistsException | MBeanRegistrationException | NotCompliantMBeanException exception) {
+            String errorMessage = String.format(
+                    "Failed to register MBean with interface [%s] for this ObjectName: [%s]",
+                    expectedServiceType, objectName
+            );
+            LOG.error(errorMessage, exception);
+        }
+    }
+
+    private <T> Optional<ObjectName> registerMBean(Class<T> expectedServiceType, T service, Map<?, ?> serviceProps) {
+        Optional<ObjectName> objectNameNullable = extractObjectName(serviceProps);
+        objectNameNullable.ifPresent(objectName -> registerMBean(expectedServiceType, service, objectName));
+        return objectNameNullable;
+    }
+}

--- a/src/test/java/org/apache/sling/jcr/oak/server/internal/WithMBeanRegistrationTest.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/internal/WithMBeanRegistrationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.oak.server.internal;
+
+import org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard;
+import org.apache.jackrabbit.oak.spi.whiteboard.Registration;
+import org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+public class WithMBeanRegistrationTest {
+
+    private static final String RAW_OBJECT_NAME = "com.example:type=TestBean";
+    private WithMBeanRegistration withMBeanRegistration;
+    private MBeanServer mBeanServer;
+
+    @SuppressWarnings({"PackageVisibleInnerClass", "MarkerInterface"})
+    interface NonPublicTestMBean {
+    }
+
+    @SuppressWarnings({"PublicInnerClass", "MarkerInterface", "WeakerAccess"})
+    public interface TestMBean {
+    }
+
+    @SuppressWarnings({"WeakerAccess", "PackageVisibleInnerClass"})
+    static class TestMBeanImpl implements NonPublicTestMBean, TestMBean {
+    }
+
+    @Before
+    public void setUp() {
+        withMBeanRegistration = new WithMBeanRegistration(new DefaultWhiteboard());
+        mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    }
+
+    private int numOfTestMBeans() throws MalformedObjectNameException {
+        Set<ObjectName> allONs = mBeanServer.queryNames(new ObjectName(RAW_OBJECT_NAME), null);
+        return allONs.size();
+    }
+
+    @Test
+    public void mustRegisterAndUnregisterMBean() throws MalformedObjectNameException {
+        Map<String, String> props = new HashMap<>();
+        props.put("jmx.objectname", RAW_OBJECT_NAME);
+        TestMBean service = new TestMBeanImpl();
+        Class<TestMBean> serviceType = TestMBean.class;
+        withMBeanRegistration.register(serviceType, service, props);
+        assertEquals(1, numOfTestMBeans());
+    }
+
+    @Test
+    public void mustRegisterAndUnregisterWithNativeONinProps() throws MalformedObjectNameException {
+        Map<String, ObjectName> props = new HashMap<>();
+        props.put("jmx.objectname", new ObjectName(RAW_OBJECT_NAME));
+        TestMBean service = new TestMBeanImpl();
+        Class<TestMBean> serviceType = TestMBean.class;
+        withMBeanRegistration.register(serviceType, service, props);
+        assertEquals(1, numOfTestMBeans());
+    }
+
+    @Test
+    public void mustUnregisterMBean() throws MalformedObjectNameException {
+        Map<String, String> props = new HashMap<>();
+        props.put("jmx.objectname", RAW_OBJECT_NAME);
+        TestMBean service = new TestMBeanImpl();
+        Class<TestMBean> serviceType = TestMBean.class;
+        Registration registration = withMBeanRegistration.register(serviceType, service, props);
+        assertEquals(1, numOfTestMBeans());
+        registration.unregister();
+        assertEquals(0, numOfTestMBeans());
+    }
+
+    @Test
+    public void mustFailRegistrationForNonPublicMBeanInterface() throws MalformedObjectNameException {
+        Map<String, String> props = new HashMap<>();
+        props.put("jmx.objectname", RAW_OBJECT_NAME);
+        NonPublicTestMBean service = new TestMBeanImpl();
+        Class<NonPublicTestMBean> serviceType = NonPublicTestMBean.class;
+        withMBeanRegistration.register(serviceType, service, props);
+        assertEquals(0, numOfTestMBeans());
+    }
+
+    @Test
+    public void mustNotRegisterMalformedObjectName() throws MalformedObjectNameException {
+        Set<ObjectName> initialONs = mBeanServer.queryNames(new ObjectName("*:*"), null);
+        int initialNumOfONs = initialONs.size();
+        String rawInvalidObjectName = "===INVALID OBJECT NAME===";
+        Map<String, String> props = new HashMap<>();
+        props.put("jmx.objectname", rawInvalidObjectName);
+        TestMBean service = new TestMBeanImpl();
+        Class<TestMBean> serviceType = TestMBean.class;
+        withMBeanRegistration.register(serviceType, service, props);
+        Set<ObjectName> finalONs = mBeanServer.queryNames(new ObjectName("*:*"), null);
+        int finalNumOfONs = finalONs.size();
+        assertEquals(initialNumOfONs, finalNumOfONs);
+    }
+
+    @Test
+    public void mustNotConflictWithWrappedWhiteboard() throws MalformedObjectNameException {
+        AtomicBoolean wasRegisteredByWrapper = new AtomicBoolean(false);
+        AtomicBoolean wasUnregisteredByWrapper = new AtomicBoolean(false);
+        Whiteboard wrappedWhiteboard = new DefaultWhiteboard() {
+            @Override
+            public <T> Registration register(Class<T> type, T service, Map<?, ?> properties) {
+                wasRegisteredByWrapper.set(true);
+                return () -> wasUnregisteredByWrapper.set(true);
+            }
+        };
+        Whiteboard wrapperWhiteboard = new WithMBeanRegistration(wrappedWhiteboard);
+        Set<ObjectName> initialONs = mBeanServer.queryNames(new ObjectName("*:*"), null);
+        int initialNumOfONs = initialONs.size();
+        String rawInvalidObjectName = "===INVALID OBJECT NAME===";
+        Map<String, String> props = new HashMap<>();
+        props.put("jmx.objectname", rawInvalidObjectName);
+        TestMBean service = new TestMBeanImpl();
+        Class<TestMBean> serviceType = TestMBean.class;
+        assertFalse(wasRegisteredByWrapper.get());
+        assertFalse(wasUnregisteredByWrapper.get());
+        Registration registration = wrapperWhiteboard.register(serviceType, service, props);
+        Set<ObjectName> finalONs = mBeanServer.queryNames(new ObjectName("*:*"), null);
+        int finalNumOfONs = finalONs.size();
+        assertEquals(initialNumOfONs, finalNumOfONs);
+        assertTrue(wasRegisteredByWrapper.get());
+        assertFalse(wasUnregisteredByWrapper.get());
+        registration.unregister();
+        assertTrue(wasUnregisteredByWrapper.get());
+    }
+}

--- a/src/test/java/org/apache/sling/jcr/oak/server/it/MBeansRegistrationIT.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/it/MBeansRegistrationIT.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.jcr.oak.server.it;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PaxExam.class)
+public class MBeansRegistrationIT extends OakServerTestSupport {
+
+    @Test
+    public void testMBeansRegistration() throws MalformedObjectNameException {
+        Set<ObjectName> expectedObjectNames = Set.of(
+                new ObjectName("org.apache.jackrabbit.oak:name=Oak Query Statistics (Extended),type=QueryStats"),
+                new ObjectName("org.apache.jackrabbit.oak:name=Oak Query Statistics,type=QueryStat"),
+                new ObjectName("org.apache.jackrabbit.oak:name=Oak Repository Statistics,type=RepositoryStats"),
+                new ObjectName("org.apache.jackrabbit.oak:name=async,type=IndexStats"),
+                new ObjectName("org.apache.jackrabbit.oak:name=async,type=PropertyIndexAsyncReindex"),
+                new ObjectName("org.apache.jackrabbit.oak:name=nodeCounter,type=NodeCounter"),
+                new ObjectName("org.apache.jackrabbit.oak:name=repository manager,type=RepositoryManagement"),
+                new ObjectName("org.apache.jackrabbit.oak:name=settings,type=QueryEngineSettings")
+        );
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        Set<ObjectName> actualObjectNames = expectedObjectNames.stream()
+                .map(expectedObjectName -> mBeanServer.queryNames(expectedObjectName, null))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+        assertEquals(expectedObjectNames, actualObjectNames);
+    }
+}


### PR DESCRIPTION
**1. Summary**

   By default, Apache Sling uses `OakSlingRepository` for repository construction. `OakSlingRepository` is, in turn, backed by `Oak`, which delivers some important MBeans (e.g., query statistics). However, due to the current specifics of the `OakSlingRepository` implementation, those MBeans aren’t registered in the MBean service registry (MBean Server). Therefore, those MBeans aren’t recognized by Apache Sling as MBeans, and their MBean features remain unavailable to the user. The proposed fix is to introduce the missing MBeans registration.

The problem is related to Apache Sling JCR Oak Repository Server (`org.apache.sling.jcr.oak.server`).

**2. Default Apache Sling Repository Construction**

   Apache Sling uses Java Content Repository (JCR) for persistence. Connections to that persistence layer are performed via `javax.jcr.Repository` implementations.

   There are several ways `javax.jcr.Repository` can be implemented and constructed. By default, in Apache Sling 12, an instance of `javax.jcr.Repository` is implemented and constructed in [`org.apache.sling.jcr.oak.server.internal.OakSlingRepositoryManager#acquireRepository()` method](https://github.com/apache/sling-org-apache-sling-jcr-oak-server/blob/0dcb90452e0cc27db3501a21a99d7de1f72c2425/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java#L131-L168) from the `org.apache.sling.jcr.oak.server` bundle. To construct the `javax.jcr.Repository`, the mentioned method utilizes `org.apache.jackrabbit.oak.Oak` from `org.apache.jackrabbit:oak-core`.

**3. Whiteboard in Oak Repository**

   During `javax.jcr.Repository` construction, `org.apache.jackrabbit.oak.Oak#with(Whiteboard)` [can be provided with a `org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard`](https://github.com/apache/jackrabbit-oak/blob/541815b62fd955d76f7069e87b9412bd7eba4daf/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java#L566-L591) from `org.apache.jackrabbit:oak-core-spi`.

   The `org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard` provided to the `org.apache.jackrabbit.oak.Oak` during `javax.jcr.Repository` construction is later used inside the `org.apache.jackrabbit.oak.Oak`, among others, to perform registration of services relevant for the repository (repository-specific services). Importantly, `org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard` is just an interface and doesn’t enforce any platform-specific logic for service registration. For instance, the `org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard` implementation just keeps services in the application memory, while the implementation provided via `org.apache.jackrabbit.oak.osgi.OsgiWhiteboard` performs registration of repository-specific services inside the OSGi service registry.

**4. MBeans in Oak Repository**

   Some repository-specific services registered inside the `org.apache.jackrabbit.oak.Oak` via the `org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard` provided during `javax.jcr.Repository` construction are MBeans. In general, those MBeans provide crucial monitoring information on the state of the repository. Specifically, at least the following MBeans are supposed to be registered:

       org.apache.jackrabbit.oak:name=Oak Query Statistics (Extended),type=QueryStats
       org.apache.jackrabbit.oak:name=Oak Query Statistics,type=QueryStat
       org.apache.jackrabbit.oak:name=Oak Repository Statistics,type=RepositoryStats
       org.apache.jackrabbit.oak:name=async,type=IndexStats
       org.apache.jackrabbit.oak:name=async,type=PropertyIndexAsyncReindex
       org.apache.jackrabbit.oak:name=nodeCounter,type=NodeCounter
       org.apache.jackrabbit.oak:name=repository manager,type=RepositoryManagement
       org.apache.jackrabbit.oak:name=settings,type=QueryEngineSettings

   In order to be recognized by the application as MBeans, repository-specific services that are MBeans [must be registered in the MBean service registry (MBean Server)](https://www.oracle.com/technical-resources/articles/javase/jmx.html). Otherwise, they will not expose their MBean features and will remain idle in this regard. Importantly, there are no limitations that forbid the registration of the same repository-specific service in separate and isolated service registries simultaneously. On the contrary, if a given repository-specific service is polymorphic and is supposed to be registered in separate and isolated service registries simultaneously, such registration might even be strongly advised. For instance, a given repository-specific service might be constructed as both an MBean service and an OSGi service, which aren’t the same and which provide different functionalities; hence it must be registered in both the MBean service registry (MBean Server) and the OSGi service registry. `org.apache.jackrabbit.oak.Oak` recognizes this polymorphic nature of some repository-specific services and by default uses a custom `org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard` implementation that [registers repository-specific services both in the in-memory service registry (`org.apache.jackrabbit.oak.spi.whiteboard.DefaultWhiteboard`) and additionally - in the case of services that are also MBeans - in the MBean service registry (MBean Server)](https://github.com/apache/jackrabbit-oak/blob/541815b62fd955d76f7069e87b9412bd7eba4daf/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java#L281-L359).

**5. Whiteboard in Default Apache Sling Repository Construction**

   During `javax.jcr.Repository` construction performed by `org.apache.sling.jcr.oak.server.internal.OakSlingRepositoryManager#acquireRepository()`, the `org.apache.jackrabbit.oak.Oak` [is constructed with an instance of `org.apache.jackrabbit.oak.osgi.OsgiWhiteboard`](https://github.com/apache/sling-org-apache-sling-jcr-oak-server/blob/0dcb90452e0cc27db3501a21a99d7de1f72c2425/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java#L133). That instance is an implementation of `org.apache.jackrabbit.oak.spi.whiteboard.Whiteboard` that registers repository-specific services exclusively in the OSGi service registry. It means that repository-specific services registered inside `org.apache.jackrabbit.oak.Oak` that are both OSGi services and MBeans are registered exclusively in the OSGi service registry and are not registered in the MBean service registry (MBean Server). Therefore, those services do not expose their MBean features and remain idle in this regard. Because of this, the Apache Sling user does not receive crucial monitoring information on the state of the repository delivered by those MBean features. For instance, they do not have access to Oak Query Statistics, which complicates query improvements.

**6. Difference in Proprietary Apache Sling Variations**

   The problem of lacking MBean features delivered by repository-specific services isn’t present in at least some proprietary variations of Apache Sling. The reason for this is that those proprietary variations don’t rely on `org.apache.sling.jcr.oak.server.internal.OakSlingRepositoryManager` used by vanilla Apache Sling for `javax.jcr.Repository` construction but use custom implementations. At least some of those implementations are performed correctly so that repository-specific services that are both MBeans and OSGi services are registered in both the MBean service registry (MBean Server) and the OSGi service registry respectively. Thanks to this, users of such Apache Sling variations do not lack MBean features of repository-specific services.

**7. Proposed Fix**

   It is proposed to fix the problem of lacking MBean features delivered by repository-specific services by registering the services that are MBeans not only in the OSGi service registry, as is already implemented, but additionally in the MBean service registry (MBean Server). To achieve this, the fix wraps `org.apache.jackrabbit.oak.osgi.OsgiWhiteboard` currently used in the `org.apache.sling.jcr.oak.server.internal.OakSlingRepositoryManager#acquireRepository()` in the decorating class `org.apache.sling.jcr.oak.server.internal.WithMBeanRegistration`. The decorator passes all method calls to the wrapped object and additionally, when registration and unregistration methods are called, registers and unregisters respectively repository-specific services that are MBeans in the MBean service registry (MBean Server). The logic of the implementation is a remake of the logic [provided by `org.apache.jackrabbit.oak.Oak`](https://github.com/apache/jackrabbit-oak/blob/541815b62fd955d76f7069e87b9412bd7eba4daf/oak-core/src/main/java/org/apache/jackrabbit/oak/Oak.java#L281-L359) and discussed above.

**8. Verification of the Fix**

   The proposed fix is verified in the integration and unit tests provided along with the fix. Additionally, it was verified on a vanilla Apache Sling 12 instance. However, note that by default, vanilla Apache Sling 12 doesn’t provide a user interface to directly interact with or see the state of the MBean service registry nor to see the statistics provided by the MBean features from repository-specific services. For such interaction, additional tooling should be installed, like [Adobe Granite JMX Support](https://mvnrepository.com/artifact/com.adobe.granite/com.adobe.granite.jmx) (`com.adobe.granite:com.adobe.granite.jmx`, http://localhost:8080/system/console/jmx) or [Jolokia](https://mvnrepository.com/artifact/org.jolokia/jolokia-osgi) (`org.jolokia:jolokia-osgi`, http://localhost:8080/jolokia/list).
