### PR TITLE
SLING-12452 - Investigate removing embeding of Oak classes

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -11,10 +11,6 @@ Import-Package:\
 Provide-Capability:\
   osgi.service;objectClass:List<String>="java.util.concurrent.Executor,org.apache.sling.commons.threads.ThreadPool"
 
--includeresource:\
-  @oak-lucene-*.jar!/org/apache/jackrabbit/oak/plugins/index/lucene/util/LuceneIndexHelper.*,\
-  @oak-search-*.jar!/org/apache/jackrabbit/oak/plugins/index/search/util/IndexHelper.*
-
 -removeheaders:\
   Include-Resource,\
   Private-Package

--- a/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerTestSupport.java
@@ -177,6 +177,8 @@ public abstract class OakServerTestSupport extends TestSupport {
         return new Option[]{
             baseConfiguration(),
             quickstart(),
+            mavenBundle("org.apache.jackrabbit", "oak-lucene", "1.56.0"), // needed for LuceneIndexHelper
+            mavenBundle("org.apache.jackrabbit", "oak-store-document", "1.56.0"), // needed by oak-lucene
             // Sling JCR Oak Server
             testBundle("bundle.filename"),
         };


### PR DESCRIPTION
- IndexHelper is no longer used, remove the embedding
- LuceneIndexHelper is used but exported by oak-lucene, remove the emebedding
- add oak-lucene and oak-store-document to the test setup to satisfy dependencies