### PR TITLE
SLING-12453 - Adapt to changes from OAK-10849 and OAK-10768

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,3 +1,4 @@
+# org.apache.jackrabbit.oak.spi.query - import range is safe since OAK-10849 and OAK-10768 do not affect us
 Import-Package:\
   com.mongodb;resolution:=optional,\
   org.apache.felix.jaas.boot,\
@@ -6,6 +7,7 @@ Import-Package:\
   org.apache.jackrabbit.oak.spi.security.authentication,\
   org.apache.jackrabbit.oak.spi.security.principal;version="[1.5,3)",\
   org.apache.jackrabbit.test;resolution:=optional,\
+  org.apache.jackrabbit.oak.spi.query;version="[1.7,4)", \
   *
 
 Provide-Capability:\


### PR DESCRIPTION
The o.a.j.oak.spi.query package package version was bumped to 3.0.0 due to breaking changes in API.

The changes had to do with the slf4j migration and don't affect how the Oak Server bundle uses that API. Rather than upgrade our requirements to a newer version we bump the import version for the oak package since we are not affected by those changes.