### PR TITLE
SLING-12848 - Add ContentRepository registration

### DIFF
--- a/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java
+++ b/src/main/java/org/apache/sling/jcr/oak/server/internal/OakSlingRepositoryManager.java
@@ -27,6 +27,7 @@ import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.JackrabbitRepository;
 import org.apache.jackrabbit.oak.InitialContent;
 import org.apache.jackrabbit.oak.Oak;
+import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.jackrabbit.oak.jcr.Jcr;
 import org.apache.jackrabbit.oak.osgi.OsgiWhiteboard;
 import org.apache.jackrabbit.oak.plugins.commit.JcrConflictHandler;
@@ -107,6 +108,7 @@ public class OakSlingRepositoryManager extends AbstractSlingRepositoryManager {
     private SecurityProvider securityProvider;
 
     private ServiceRegistration<NodeAggregator> nodeAggregatorRegistration;
+    private ServiceRegistration<ContentRepository> contentRepositoryRegistration;
 
     @Override
     protected ServiceUserMapper getServiceUserMapper() {
@@ -148,7 +150,8 @@ public class OakSlingRepositoryManager extends AbstractSlingRepositoryManager {
             jcr.with(commitRateLimiter);
         }
 
-        jcr.createContentRepository();
+        ContentRepository contentRepository = jcr.createContentRepository();
+        contentRepositoryRegistration = bundleContext.registerService(ContentRepository.class, contentRepository, null);
 
         return new TcclWrappingJackrabbitRepository((JackrabbitRepository) jcr.createRepository());
     }
@@ -200,6 +203,7 @@ public class OakSlingRepositoryManager extends AbstractSlingRepositoryManager {
         super.stop();
         this.componentContext = null;
         this.nodeAggregatorRegistration.unregister();
+        this.contentRepositoryRegistration.unregister();
     }
 
     private String getAdminId() {

--- a/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerIT.java
+++ b/src/test/java/org/apache/sling/jcr/oak/server/it/OakServerIT.java
@@ -34,6 +34,7 @@ import javax.jcr.SimpleCredentials;
 import javax.jcr.query.Query;
 
 import org.apache.jackrabbit.commons.cnd.CndImporter;
+import org.apache.jackrabbit.oak.api.ContentRepository;
 import org.apache.sling.api.SlingConstants;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -41,6 +42,7 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
@@ -49,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 @RunWith(PaxExam.class)
@@ -337,6 +340,14 @@ public class OakServerIT extends OakServerTestSupport {
         }
 
         log.info("Running on Oak version {}", repository.getDescriptor("jcr.repository.version"));
+    }
+
+    @Test
+    public void testContentRepositoryRegistration() {
+        ServiceReference<ContentRepository> serviceReference = bundleContext.getServiceReference(
+                ContentRepository.class
+        );
+        assertNotNull("Content Repository service must be registered", serviceReference);
     }
 
 }


### PR DESCRIPTION
1. Jackrabbit Oak has internal dependencies on the `org.apache.jackrabbit.oak.api.ContentRepository` service. For instance, the registration of `org.apache.jackrabbit.oak.spi.security.authentication.external.impl.jmx.SynchronizationMBean` as a JMX MBean will not occur if a `ContentRepository` service is unavailable (https://github.com/apache/jackrabbit-oak/blob/b5c317af752b3c421c9d341a7cfca407dff29af5/oak-auth-external/src/main/java/org/apache/jackrabbit/oak/spi/security/authentication/external/impl/ExternalLoginModuleFactory.java#L203-L206).

2. A standard Apache Sling application based on the Apache Sling Starter does not register a `ContentRepository` service, and no such logic is implemented in any of the Apache Sling bundles. Therefore, code that is dependent on the existence of a registered `ContentRepository` service does not work as expected. Among other things, the registration of a `SynchronizationMBean` as a JMX MBean does not happen.

3. The proposed solution is to introduce the `ContentRepository` registration in the `sling-org-apache-sling-jcr-oak-server` bundle, which is responsible for repository initialization. This solution was agreed upon in this email thread: https://lists.apache.org/thread/xt4r7zo7gr4z0ppymp9flfcyvfj6yg97.